### PR TITLE
use dill to save checkpoint structure along with data

### DIFF
--- a/conf/checkpoint.yaml
+++ b/conf/checkpoint.yaml
@@ -1,13 +1,14 @@
 checkpoint:
   save: False
   load: False
-  # if save is true, save checkpoint to "/checkpoint/{save_path}/iter_{it}.json" when it % save_steps = 0
+  # if save is true, save checkpoint to "{save_path}/iter_{it}.ckpt" when it % save_steps = 0
   save_path: null
+  # save checkpoints every {save_steps} iterations
   save_steps: null
-  # if load is true, load checkpoint from "/checkpoint/{load_path}"
+  # if load is true, load checkpoint from "{load_path}"
   load_path: null
   # if not None, specify total steps in one checkpoint training
   num_steps: null
-  # USE WITH CAUTION: if true, overwrite the existing "/checkpoint/{save_path}/config.yaml".
+  # USE WITH CAUTION: if true, overwrite the existing "{save_path}/config.yaml".
   # This could result in two chcekpoint runs having different configurations.
   overwrite: False

--- a/serialize/serializer.py
+++ b/serialize/serializer.py
@@ -1,0 +1,60 @@
+import jax
+import equinox as eqx
+from typing import NamedTuple, Optional
+import numpy as np
+from jax import tree_util as jtu
+from jaxtyping import PyTree
+import dill
+from jax import numpy as jnp
+
+
+class ArrayShape(NamedTuple):
+    shape: np.ndarray
+    dtype: np.dtype
+
+
+def get_structure(pytree):
+    def get_type(p):
+        if eqx.is_array(p):
+            return ArrayShape(shape=p.shape, dtype=p.dtype)
+        else:
+            return p
+
+    return jtu.tree_map(
+        get_type,
+        pytree,
+    )
+
+
+def save(path: str, pytree: PyTree, save_structure: bool = True) -> None:
+    with open(path, "wb") as f:
+        if save_structure:
+            dill.dump(get_structure(pytree), f)
+        else:
+            # just dump a "None" flag into the file.
+            # this can be used to check if the the structure was saved
+            # if necessary.
+            dill.dump(None, f)
+        eqx.tree_serialise_leaves(f, pytree)
+
+
+def load(path: str, structure: Optional[PyTree] = None) -> PyTree:
+    def create_arrays(p):
+        if isinstance(p, ArrayShape):
+            return jnp.zeros(p.shape, dtype=p.dtype)
+        else:
+            return p
+
+    with open(path, "rb") as f:
+        if structure is None:
+            structure = jtu.tree_map(
+                create_arrays,
+                dill.load(f),
+                is_leaf=lambda p: isinstance(p, ArrayShape),
+            )
+        else:
+            # read out and drop the structure
+            _ = dill.load(f)
+        result = eqx.tree_deserialise_leaves(f, structure)
+
+    return result


### PR DESCRIPTION
Fix up checkpoint loading a bit, and allow storing the structure with the checkpoint.
We use the dill module for this rather than pickle because pickle does not work.
I'm honestly not sure what the disadvantage is of dill vs pickle, but if there is one, it seems likely that it's not one that is important at the moment here.

In action:
https://wandb.ai/optimizedlearning/test_trainit/runs/l4ki7ol1?nw=nwusercutkosky
saved at iteration 1000, picked up again here:
https://wandb.ai/optimizedlearning/test_trainit/runs/k7w1vj5g?nw=nwusercutkosky

Notice that the tokens count is apparently not part of the train state yet, and so was reset here.