### PR TITLE
added implicit gradient transport

### DIFF
--- a/_src/optimizer.py
+++ b/_src/optimizer.py
@@ -313,7 +313,7 @@ def init_optimizer(
             beta2=config.beta2,
             offset_beta=config.offset_beta,
             normalizations=OmegaConf.to_container(config.normalizations),
-            schedule_wrapper=schedule_wrapper
+            schedule_wrapper=schedule_wrapper,
         )
         if config.visualize:
             optimizer = optax.chain(
@@ -342,7 +342,8 @@ def init_optimizer(
             num_heads=num_heads,
             offset_beta=config.offset_beta,
             schedule=base_schedule,
-            schedule_wrapper=schedule_wrapper
+            schedule_wrapper=schedule_wrapper,
+            igt_scale=config.igt_scale,
         )
     
     # Initialize base optimizer.

--- a/conf/optimizer/mango_v2.yaml
+++ b/conf/optimizer/mango_v2.yaml
@@ -65,13 +65,13 @@ normalize:
   vec_b: "l2"
 
 scale_weight:
-  mat: "op"
+  mat: null #"op"
   embedding: null
-  head: "op"
-  attn_w: "op"
-  attn_b: "l2"
+  head: null #"op"
+  attn_w: null #"op"
+  attn_b: null #"l2"
   vec_w: null
-  vec_b: "l2"
+  vec_b: null #"l2"
 
 scale_power:
   mat: 1
@@ -81,6 +81,8 @@ scale_power:
   attn_b: 1
   vec_w: 1
   vec_b: 1
+
+igt_scale: 0.0
 
 # log norms of each layer to wandb
 visualize: False


### PR DESCRIPTION
* Added implicit gradient transport with a tunable scaling factor inspired by the gamma parameter in MARS.
* moved offset momentum into mango_component so that igt can access beta1 after offset_momentum is applied. In general, perhaps we should just do everything from within in mango_component.
experiment log: https://wandb.ai/optimizedlearning/mango_test_ashok/workspace?nw=nwusercutkosky